### PR TITLE
stop blocking root in robots.txt

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -33,7 +33,7 @@ echo 'Rendering nginx confs'
 sudo rm -rf /etc/nginx
 shopt -s globstar
 # Defaults
-[ "$ROBOTS_DISALLOW" ] || export ROBOTS_DISALLOW=
+[ ! "$ROBOTS_DISALLOW" ] && export ROBOTS_DISALLOW=/
 for f in nginx/**; do
   [ ! -f "$f" ] && continue
   sudo mkdir -p "$(dirname "/etc/$f")"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -33,7 +33,7 @@ echo 'Rendering nginx confs'
 sudo rm -rf /etc/nginx
 shopt -s globstar
 # Defaults
-[ "$ROBOTS_DISALLOW" ] || export ROBOTS_DISALLOW=/
+[ "$ROBOTS_DISALLOW" ] || export ROBOTS_DISALLOW=
 for f in nginx/**; do
   [ ! -f "$f" ] && continue
   sudo mkdir -p "$(dirname "/etc/$f")"


### PR DESCRIPTION
Removes a `/` set in deploy script preventing homepage indexing by search engines
